### PR TITLE
Feat/mac os proxy

### DIFF
--- a/app/ops/utils.py
+++ b/app/ops/utils.py
@@ -72,7 +72,7 @@ def set_socks_system_proxy(ip_address, port):
         try:
             services = subprocess.check_output(["networksetup", "-listallnetworkservices"]).decode().splitlines()
             for service in services:
-                if not service.strip() or service.startswith("*"):
+                if not service.strip() or service.startswith("*") or service.__contains__("*"):
                     continue
                 subprocess.run(
                     [

--- a/app/ops/utils.py
+++ b/app/ops/utils.py
@@ -72,7 +72,7 @@ def set_socks_system_proxy(ip_address, port):
         try:
             services = subprocess.check_output(["networksetup", "-listallnetworkservices"]).decode().splitlines()
             for service in services:
-                if not service.strip() or service.startswith("*") or service.__contains__("*"):
+                if not service.strip() or service.__contains__("*"):
                     continue
                 subprocess.run(
                     [


### PR DESCRIPTION
ERROR:root:Failed to set macOS proxy: Command '['networksetup', '-setsocksfirewallproxy', 'An asterisk (*) denotes that a network service is disabled.', '127.0.0.1', '10808']' returned non-zero exit status 4.